### PR TITLE
Fixed issue with inhomogeneous shape when plotting frequency's after using MEASURE_LINEAR_VIBRATIONS_RANGE

### DIFF
--- a/linear_movement_vibrations.py
+++ b/linear_movement_vibrations.py
@@ -432,7 +432,9 @@ class LinearMovementVibrationsTest:
             plt.savefig(outfile)
             gcmd.respond_info("output written to {}".format(outfile))
             plt.close('all')
+            
         except Exception as error:
+            print("Custom error message")
             print(error)
 
 

--- a/linear_movement_vibrations.py
+++ b/linear_movement_vibrations.py
@@ -413,24 +413,27 @@ class LinearMovementVibrationsTest:
 
     @staticmethod
     def _plot_frequency_responses_over_velocity(data, outfile, axis, gcmd):
-        data = np.array(data)
-        plt.ioff()
-        fig = plt.figure()
-        ax = fig.add_subplot(projection='3d')
-        fig.suptitle("Vibration peak frequencies for axis {}".format(axis))
-        ax.ticklabel_format(style='sci', axis='z', scilimits=(0, 0))
+        try:
+            data = np.array(data)
+            plt.ioff()
+            fig = plt.figure()
+            ax = fig.add_subplot(projection='3d')
+            fig.suptitle("Vibration peak frequencies for axis {}".format(axis))
+            ax.ticklabel_format(style='sci', axis='z', scilimits=(0, 0))
 
-        for velocity_sample in data:
-            x = velocity_sample[1]
-            y = velocity_sample[2]
-            z = velocity_sample[0]
-            ax.plot(x, y, zs=z, zdir='y')
-        ax.set_xlabel("f in Hz")
-        ax.set_zlabel("relative response")
-        ax.set_ylabel("velocity")
-        plt.savefig(outfile)
-        gcmd.respond_info("output written to {}".format(outfile))
-        plt.close('all')
+            for velocity_sample in data:
+                x = velocity_sample[1]
+                y = velocity_sample[2]
+                z = velocity_sample[0]
+                ax.plot(x, y, zs=z, zdir='y')
+            ax.set_xlabel("f in Hz")
+            ax.set_zlabel("relative response")
+            ax.set_ylabel("velocity")
+            plt.savefig(outfile)
+            gcmd.respond_info("output written to {}".format(outfile))
+            plt.close('all')
+        except Exception as error:
+            print(error)
 
 
 def load_config(config):

--- a/linear_movement_vibrations.py
+++ b/linear_movement_vibrations.py
@@ -413,29 +413,25 @@ class LinearMovementVibrationsTest:
 
     @staticmethod
     def _plot_frequency_responses_over_velocity(data, outfile, axis, gcmd):
-        try:
-            data = np.array(data, dtype=object)
-            plt.ioff()
-            fig = plt.figure()
-            ax = fig.add_subplot(projection='3d')
-            fig.suptitle("Vibration peak frequencies for axis {}".format(axis))
-            ax.ticklabel_format(style='sci', axis='z', scilimits=(0, 0))
+        data = np.array(data, dtype=object)
+        plt.ioff()
+        fig = plt.figure()
+        ax = fig.add_subplot(projection='3d')
+        fig.suptitle("Vibration peak frequencies for axis {}".format(axis))
+        ax.ticklabel_format(style='sci', axis='z', scilimits=(0, 0))
 
-            for velocity_sample in data:
-                x = velocity_sample[1]
-                y = velocity_sample[2]
-                z = velocity_sample[0]
-                ax.plot(x, y, zs=z, zdir='y')
-            ax.set_xlabel("f in Hz")
-            ax.set_zlabel("relative response")
-            ax.set_ylabel("velocity")
-            plt.savefig(outfile)
-            gcmd.respond_info("output written to {}".format(outfile))
-            plt.close('all')
+        for velocity_sample in data:
+            x = velocity_sample[1]
+            y = velocity_sample[2]
+            z = velocity_sample[0]
+            ax.plot(x, y, zs=z, zdir='y')
+        ax.set_xlabel("f in Hz")
+        ax.set_zlabel("relative response")
+        ax.set_ylabel("velocity")
+        plt.savefig(outfile)
+        gcmd.respond_info("output written to {}".format(outfile))
+        plt.close('all')
             
-        except Exception as error:
-            print("Custom error message")
-            print(error)
 
 
 def load_config(config):

--- a/linear_movement_vibrations.py
+++ b/linear_movement_vibrations.py
@@ -414,7 +414,7 @@ class LinearMovementVibrationsTest:
     @staticmethod
     def _plot_frequency_responses_over_velocity(data, outfile, axis, gcmd):
         try:
-            data = np.array(data)
+            data = np.array(data, dtype=object)
             plt.ioff()
             fig = plt.figure()
             ax = fig.add_subplot(projection='3d')

--- a/linear_vibrations_macro.cfg
+++ b/linear_vibrations_macro.cfg
@@ -1,0 +1,62 @@
+[mcu adxl]
+serial: /dev/serial/by-id/usb-Klipper_rp2040_E6626005A71B4F34-if00
+                                      
+[adxl345]
+cs_pin: adxl:gpio9
+spi_software_sclk_pin: adxl:gpio10
+spi_software_mosi_pin: adxl:gpio11
+spi_software_miso_pin: adxl:gpio12
+
+[resonance_tester]
+accel_chip:adxl345
+probe_points:
+    147,154, 20
+
+[linear_movement_vibrations]
+accel_chip: adxl345
+x_min: 5
+x_max: 175
+y_min: 5
+y_max: 175
+output_directory: /tmp/linear_vibrations/
+
+[gcode_macro test_accel]
+gcode:
+  ACCELEROMETER_QUERY
+
+[gcode_macro X_INPUTSHAPER]
+gcode:
+  _CG28
+  TEST_RESONANCES AXIS=X
+
+[gcode_macro Y_INPUTSHAPER]
+gcode:
+  _CG28
+  TEST_RESONANCES AXIS=Y
+
+[gcode_macro _CG28]
+gcode:
+    {% if "xyz" not in printer.toolhead.homed_axes %}
+        G28
+    {% endif %}
+
+[gcode_macro Linear_vibration_const_speed]
+description: Run linear vibration for x,y,a,b axis at one velocity
+gcode:
+  _CG28
+  G1 Z20
+  {% set speed = params.SPEED|default(150)|int %} 
+  {% set axis = params.AXIS|string %}
+  MEASURE_LINEAR_VIBRATIONS VELOCITY={speed} AXIS={axis}
+
+[gcode_macro Linear_vibration_speed_range]
+description: Run linear vibration for x,y,a,b axis at one velocity
+gcode:
+  _CG28
+  G1 Z20
+  {% set axis = params.AXIS|string %}
+  {% set vmin = params.VMIN|default(50)|int %}
+  {% set vmax = params.VMAX|default(250)|int %}
+  {% set step = params.STEP|default(10)|int %}
+  
+  MEASURE_LINEAR_VIBRATIONS_RANGE AXIS={axis} VMIN={vmin} VMAX={vmax} STEP={step}


### PR DESCRIPTION
When i used the ``MEASURE_LINEAR_VIBRATIONS_RANGE`` command i got the error:
"ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 2 dimensions. The detected shape was (21, 3) + inhomogeneous part."
I was able to fix this by adding ``dtype=object`` to ``data = np.array(data, dtype=object)``. It's most likely related to the numpy version (mine is 1.26.0).

I've also added a example config, so the command can be accessed via klipper macros.

Thank you for sharing this project. It's very useful to find good printing speeds and should be way more popular.

I might also add an csv file output (also issue #31)  to create a plot, which adds all of the vibrations of all axes to find the perfect printing speed.